### PR TITLE
[no-ticket] feat: change lodash for lodash.merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
   "name": "eslint-plugin-observers",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-observers",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "lodash": "4.17.21"
+        "lodash.merge": "4.6.2"
       },
       "devDependencies": {
         "@types/eslint": "^6.8.1",
         "@types/estree": "0.0.39",
         "@types/lodash": "4.14.179",
+        "@types/lodash.merge": "^4.6.7",
         "@types/node": "^14.0.12",
         "@typescript-eslint/eslint-plugin": "^5.54.1",
         "@typescript-eslint/parser": "^5.54.1",
@@ -371,6 +372,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
       "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==",
       "dev": true
+    },
+    "node_modules/@types/lodash.merge": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
+      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "14.18.36",
@@ -2327,16 +2337,10 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -3486,6 +3490,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
       "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==",
       "dev": true
+    },
+    "@types/lodash.merge": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
+      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/node": {
       "version": "14.18.36",
@@ -4888,16 +4901,10 @@
         "type-check": "~0.4.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.truncate": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-observers",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ESLint plugin for preventing memory leaks around observers (ResizeObserver, IntersectionObserver, MutationObserver)",
   "main": "lib/index.js",
   "scripts": {
@@ -29,17 +29,18 @@
     "url": "https://github.com/gquinteros93/eslint-plugin-observers/issues"
   },
   "homepage": "https://github.com/gquinteros93/eslint-plugin-observers",
-  "private": true,
+  "private": false,
   "peerDependencies": {
     "eslint": ">=0.8.0"
   },
   "dependencies": {
-    "lodash": "4.17.21"
+    "lodash.merge": "4.6.2"
   },
   "devDependencies": {
     "@types/eslint": "^6.8.1",
     "@types/estree": "0.0.39",
     "@types/lodash": "4.14.179",
+    "@types/lodash.merge": "^4.6.7",
     "@types/node": "^14.0.12",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.54.1",

--- a/src/rules/observers.ts
+++ b/src/rules/observers.ts
@@ -17,7 +17,7 @@ import {
   getDescription,
   isNewExpression,
 } from '../utils'
-import merge = require('lodash/merge');
+import merge = require('lodash.merge')
 
 enum ObserversTypes {
   MutationObserver = 'MutationObserver',


### PR DESCRIPTION
# Summary

This PR replaces [lodash](https://www.npmjs.com/package/lodash) for [lodash.merge](https://www.npmjs.com/package/lodash.merge) because we don't need the entire library when in fact we use a single function. 

# Improvement

Thanks to this change we reduced the package size around 0.6 kB

| Before | After | 
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/53574912/224280729-7796a302-2e2b-4832-8b09-ce6c14b82586.png) | ![image](https://user-images.githubusercontent.com/53574912/224280743-8c9d63c9-db5a-40a6-8f94-cdb6d8276fca.png) | 